### PR TITLE
Fix broken README Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,19 +69,19 @@ It is also based on the LDML spec, C.11 Language Plural Rules:
 
 #### Prior Art
 
-- Java
+##### Java
 
-  - [ICU](http://icu-project.org/apiref/icu4j/com/ibm/icu/text/RelativeDateTimeFormatter.html): `com.ibm.icu.impl.RelativeDateFormat`
-  - `org.ocpsoft.prettytime.PrettyTime`
+- [ICU](http://icu-project.org/apiref/icu4j/com/ibm/icu/text/RelativeDateTimeFormatter.html): `com.ibm.icu.impl.RelativeDateFormat`
+- `org.ocpsoft.prettytime.PrettyTime`
 
-- Ruby
+##### Ruby
 
-  ```ruby
-  include ActionView::Helpers::DateHelper
-  def index
-    @friendly_date = time_ago_in_words(Date.today - 1)
-  end
-  ```
+```ruby
+include ActionView::Helpers::DateHelper
+def index
+  @friendly_date = time_ago_in_words(Date.today - 1)
+end
+```
 
 #### Naming
 


### PR DESCRIPTION
The code block of Ruby seems to break README. I think this change resolve this issue.