### PR TITLE
Normative: Treat -0 as past

### DIFF
--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -92,13 +92,13 @@
         1. If _exists_ is *false*, then
           1. Let _entry_ be _unit_.
         1. Let _patterns_ be ? Get(_fields_, _entry_).
-        1. Let _type be _relativeTimeFormat_.[[Type]].
+        1. Let _type_ be _relativeTimeFormat_.[[Type]].
         1. If _type_ is equal to `"text"`, then
           1. Let _exists_ be ? HasProperty(_patterns_, ToString(_value_)).
           1. If _exists_ is *true*, then
             1. Let _result_ be Get(_patterns_, ToString(_value_)).
             1. Return a List containing the Record { [[Type]]: `"literal"`, [[Value]]: _result_ }.
-        1. If _value_ is less than 0, then
+        1. If _value_ is *-0* or if _value_ is less than 0, then
           1. Let _tl_ be `"past"`.
         1. Else
           1. Let _tl_ be `"future"`.


### PR DESCRIPTION
Previously, -0 was treated as a future time. However, this is
likely to not meet programmer expectations, as documented by
@rxaviers in #58.

@zbraniecki reported that he attempted to implement these semantics in
SpiderMonkey. Related ICU bug: http://bugs.icu-project.org/trac/ticket/12936.
cc @srl295

Closes #58