### PR TITLE
Create options objects with null prototype (fixes #76).

### DIFF
--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -35,12 +35,12 @@
         1. Assert: _fields_ is an object (see <emu-xref href="#sec-Intl.RelativeTimeFormat-internal-slots"></emu-xref>).
         1. Set _relativeTimeFormat_.[[Fields]] to _fields_.
         1. Let _nfLocale_ be CreateArrayFromList(« _locale_ »).
-        1. Let _nfOptions_ be ObjectCreate(%ObjectPrototype%).
+        1. Let _nfOptions_ be ObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, `"useGrouping"`, *false*).
         1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, `"minimumIntegerDigits"`, *2*).
         1. Let _relativeTimeFormat_.[[NumberFormat]] be ? Construct(%NumberFormat%, « _nfLocale_, _nfOptions_ »).
         1. Let _prLocale_ be CreateArrayFromList(« _locale_ »).
-        1. Let _prOptions_ be ObjectCreate(%ObjectPrototype%).
+        1. Let _prOptions_ be ObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_prOptions_, `"style"`, `"cardinal"`).
         1. Let _relativeTimeFormat_.[[PluralRules]] be ? Construct(%PluralRules%, « _prLocale_, _prOptions_ »).
         1. Return _relativeTimeFormat_.


### PR DESCRIPTION
The current specification accidentally requires that the NumberFormat and
PluralRules constructors get properties off Object.prototype. This is not
particularly useful, and is not implemented in SpiderMonkey.