### PR TITLE
Normative: Remove mistaken NumberFormat options

### DIFF
--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -35,10 +35,7 @@
         1. Assert: _fields_ is an object (see <emu-xref href="#sec-Intl.RelativeTimeFormat-internal-slots"></emu-xref>).
         1. Set _relativeTimeFormat_.[[Fields]] to _fields_.
         1. Let _nfLocale_ be CreateArrayFromList(« _locale_ »).
-        1. Let _nfOptions_ be ObjectCreate(*null*).
-        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, `"useGrouping"`, *false*).
-        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, `"minimumIntegerDigits"`, *2*).
-        1. Let _relativeTimeFormat_.[[NumberFormat]] be ? Construct(%NumberFormat%, « _nfLocale_, _nfOptions_ »).
+        1. Let _relativeTimeFormat_.[[NumberFormat]] be ? Construct(%NumberFormat%, « _nfLocale_ »).
         1. Let _prLocale_ be CreateArrayFromList(« _locale_ »).
         1. Let _prOptions_ be ObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_prOptions_, `"style"`, `"cardinal"`).

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -34,12 +34,9 @@
         1. Let _fields_ be Get(_localeData_, _dataLocale_).
         1. Assert: _fields_ is an object (see <emu-xref href="#sec-Intl.RelativeTimeFormat-internal-slots"></emu-xref>).
         1. Set _relativeTimeFormat_.[[Fields]] to _fields_.
-        1. Let _nfLocale_ be CreateArrayFromList(« _locale_ »).
-        1. Let _relativeTimeFormat_.[[NumberFormat]] be ? Construct(%NumberFormat%, « _nfLocale_ »).
-        1. Let _prLocale_ be CreateArrayFromList(« _locale_ »).
-        1. Let _prOptions_ be ObjectCreate(*null*).
-        1. Perform ! CreateDataPropertyOrThrow(_prOptions_, `"style"`, `"cardinal"`).
-        1. Let _relativeTimeFormat_.[[PluralRules]] be ? Construct(%PluralRules%, « _prLocale_, _prOptions_ »).
+        1. Let _relativeTimeFormat_.[[NumberFormat]] be ? Construct(%NumberFormat%, « _locale_ »).
+        1. Let _relativeTimeFormat_.[[PluralRules]] be ? Construct(%PluralRules%, « _locale_ »).
+        1. Set _relativeTimeFormat_.[[InitializedRelativeTimeFormat]] to *true*.
         1. Return _relativeTimeFormat_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
The NumberFormat object that RelativeTimeFormat uses internally was
previously given options to set the minimum integer digits to 2 and
turn off grouping separators. It seems that both of these options
were set mistakenly, and the default settings for NumberFormat would
be preferable. This patch removes those options.

Fixes #80