### PR TITLE
Editorial: Fix editorial nits

### DIFF
--- a/spec/biblio.json
+++ b/spec/biblio.json
@@ -1,4 +1,11 @@
 {
+  "https://tc39.github.io/ecma262/": [
+    {
+      "type": "op",
+      "aoid": "string-concatenation",
+      "id": "sec-ecmascript-language-types-string-type"
+    }
+  ],
   "https://tc39.github.io/ecma402/": [
     {
       "type": "op",
@@ -19,6 +26,26 @@
       "type": "op",
       "aoid": "SupportedLocales",
       "id": "sec-supportedlocales"
+    },
+    {
+      "type": "op",
+      "aoid": "PartitionNumberPattern",
+      "id": "sec-partitionnumberpattern"
+    },
+    {
+      "type": "op",
+      "aoid": "ResolvePlural",
+      "id": "sec-resolveplural"
+    },
+    {
+      "type": "term",
+      "term": "%StringProto_indexOf%",
+      "id": "sec-402-well-known-intrinsic-objects"
+    },
+    {
+      "type": "clause",
+      "number": "9.1",
+      "id": "sec-internal-slots"
     }
   ]
 }

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -17,13 +17,13 @@
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
           1. Let _options_ be ObjectCreate(*null*).
-        1. Else
+        1. Else,
           1. Let _options_ be ? ToObject(_options_).
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, «`"lookup"`, `"best fit"`», `"best fit"`).
         1. Set _opt_.[[LocaleMatcher]] to _matcher_.
-        1. Let _localeData_ be *%RelativeTimeFormat%*.[[LocaleData]].
-        1. Let _r_ be ResolveLocale(*%RelativeTimeFormat%*.[[AvailableLocales]], _requestedLocales_, _opt_, *%RelativeTimeFormat%*.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _localeData_ be %RelativeTimeFormat%.[[LocaleData]].
+        1. Let _r_ be ResolveLocale(%RelativeTimeFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %RelativeTimeFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Let _locale_ be _r_.[[Locale]].
         1. Set _relativeTimeFormat_.[[Locale]] to _locale_.
         1. Let _dataLocale_ be _r_.[[DataLocale]].
@@ -31,11 +31,11 @@
         1. Set _relativeTimeFormat_.[[Style]] to _s_.
         1. Let _numeric_ be ? GetOption(_options_, `"numeric"`, `"string"`, «`"always"`, `"auto"`», `"always"`).
         1. Set _relativeTimeFormat_.[[Numeric]] to _numeric_.
-        1. Let _fields_ be Get(_localeData_, _dataLocale_).
+        1. Let _fields_ be ! Get(_localeData_, _dataLocale_).
         1. Assert: _fields_ is an object (see <emu-xref href="#sec-Intl.RelativeTimeFormat-internal-slots"></emu-xref>).
         1. Set _relativeTimeFormat_.[[Fields]] to _fields_.
-        1. Let _relativeTimeFormat_.[[NumberFormat]] be ? Construct(%NumberFormat%, « _locale_ »).
-        1. Let _relativeTimeFormat_.[[PluralRules]] be ? Construct(%PluralRules%, « _locale_ »).
+        1. Let _relativeTimeFormat_.[[NumberFormat]] be ! Construct(%NumberFormat%, « _locale_ »).
+        1. Let _relativeTimeFormat_.[[PluralRules]] be ! Construct(%PluralRules%, « _locale_ »).
         1. Return _relativeTimeFormat_.
       </emu-alg>
     </emu-clause>
@@ -52,7 +52,7 @@
         1. If _unit_ is `"months"`, return `"month"`.
         1. If _unit_ is `"quarters"`, return `"quarter"`.
         1. If _unit_ is `"years"`, return `"year"`.
-        1. If _unit_ is not one of `"second"`, `"minute"`, `"hour"`, `"day"`, `"week"`, `"month"`, `"quarter"`, `"year"`, throw a RangeError exception.
+        1. If _unit_ is not one of `"second"`, `"minute"`, `"hour"`, `"day"`, `"week"`, `"month"`, `"quarter"`, or `"year"`, throw a *RangeError* exception.
         1. Return _unit_.
       </emu-alg>
     </emu-clause>
@@ -66,37 +66,37 @@
 
       <emu-alg>
         1. Assert: _relativeTimeFormat_ has an [[InitializedRelativeTimeFormat]] internal slot.
-        1. Assert: Type(_value_) is a Number.
-        1. Assert: Type(_unit_) is a String.
-        1. If _value_ is *NaN*, *+&infin;*, or *-&infin;*, then throw a *RangeError* exception.
+        1. Assert: Type(_value_) is Number.
+        1. Assert: Type(_unit_) is String.
+        1. If _value_ is *NaN*, *+&infin;*, or *-&infin;*, throw a *RangeError* exception.
         1. Let _unit_ be ? SingularRelativeTimeUnit(_unit_).
         1. Let _fields_ be _relativeTimeFormat_.[[Fields]].
         1. Let _style_ be _relativeTimeFormat_.[[Style]].
-        1. If _style_ is equal to "short", then
-          1. Let _entry_ be the string-concatenation of _unit_ and "-short".
-        1. Else if _style_ is equal to "narrow", then
-          1. Let _entry_ be the string-concatenation of _unit_ and "-narrow".
-        1. Else
+        1. If _style_ is equal to `"short"`, then
+          1. Let _entry_ be the string-concatenation of _unit_ and `"-short"`.
+        1. Else if _style_ is equal to `"narrow"`, then
+          1. Let _entry_ be the string-concatenation of _unit_ and `"-narrow"`.
+        1. Else,
           1. Let _entry_ be _unit_.
-        1. Let _exists_ be ? HasProperty(_fields_, _entry_).
+        1. Let _exists_ be ! HasProperty(_fields_, _entry_).
         1. If _exists_ is *false*, then
           1. Let _entry_ be _unit_.
-        1. Let _patterns_ be ? Get(_fields_, _entry_).
+        1. Let _patterns_ be ! Get(_fields_, _entry_).
         1. Let _numeric_ be _relativeTimeFormat_.[[Numeric]].
         1. If _numeric_ is equal to `"auto"`, then
-          1. Let _exists_ be ? HasProperty(_patterns_, ToString(_value_)).
+          1. Let _exists_ be ! HasProperty(_patterns_, ! ToString(_value_)).
           1. If _exists_ is *true*, then
-            1. Let _result_ be Get(_patterns_, ToString(_value_)).
+            1. Let _result_ be ! Get(_patterns_, ! ToString(_value_)).
             1. Return a List containing the Record { [[Type]]: `"literal"`, [[Value]]: _result_ }.
         1. If _value_ is *-0* or if _value_ is less than 0, then
           1. Let _tl_ be `"past"`.
-        1. Else
+        1. Else,
           1. Let _tl_ be `"future"`.
-        1. Let _po_ be ? Get(_patterns_, _tl_).
+        1. Let _po_ be ! Get(_patterns_, _tl_).
         1. Let _fv_ be ! PartitionNumberPattern(_relativeTimeFormat_.[[NumberFormat]], _value_).
         1. Let _pr_ be ! ResolvePlural(_relativeTimeFormat_.[[PluralRules]], _value_).
-        1. Let _pattern_ be ? Get(_po_, _pr_).
-        1. Return ? MakePartsList(_pattern_, _unit_, _fv_).
+        1. Let _pattern_ be ! Get(_po_, _pr_).
+        1. Return ! MakePartsList(_pattern_, _unit_, _fv_).
       </emu-alg>
     </emu-clause>
 
@@ -108,7 +108,7 @@
         <emu-note>
         Example:
         <pre>
-          MakePartsList("AA{0}BB", "hour", &laquo; { [[Type]]: "integer", [[Value]]: "15" } &raquo; )  --&lt;
+          MakePartsList("AA{0}BB", "hour", &laquo; { [[Type]]: "integer", [[Value]]: "15" } &raquo; )
 
         Output (List of Records):
           &laquo;
@@ -120,22 +120,21 @@
       </p>
       <emu-alg>
         1. Let _result_ be a new empty List.
-        1. Let _beginIndex_ be Call(%StringProto_indexOf%, _pattern_, "{", *0*).
-        1. Let _length_ be ! Get(_pattern_, `"length"`).
-        1. Assert: _length_ is a non-negative integer.
-        1. Repeat while _beginIndex_ is an integer index into _pattern_:
-          1. Set _endIndex_ to Call(%StringProto_indexOf%, _pattern_, "}", _beginIndex_)
+        1. Let _beginIndex_ be ! Call(%StringProto_indexOf%, _pattern_, « "{", *0* »).
+        1. Let _length_ be the number of elements in _pattern_.
+        1. Repeat, while _beginIndex_ is an integer index into _pattern_
+          1. Set _endIndex_ to ! Call(%StringProto_indexOf%, _pattern_, « "}", _beginIndex_ »).
           1. Assert: _endIndex_ is not -1, otherwise the pattern would be malformed.
-          1. If _beginIndex_ is greater than _nextIndex_, then:
+          1. If _beginIndex_ is greater than _nextIndex_, then
             1. Let _literal_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
-            1. Add new part record { [[Type]]: `"literal"`, [[Value]]: _literal_ } as a new element of the list _result_.
+            1. Add new part Record { [[Type]]: `"literal"`, [[Value]]: _literal_ } as a new element of the list _result_.
           1. Let _p_ be the substring of _pattern_ from position _beginIndex_, exclusive, to position _endIndex_, exclusive.
           1. Assert: _p_ is `"0"`.
-          1. For each _part_ in _parts_:
+          1. For each _part_ in _parts_, do
             1. Add new part Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: _unit_ } as a new element on the List _result_.
-        1. If _nextIndex_ is less than _length_, then:
+        1. If _nextIndex_ is less than _length_, then
           1. Let _literal_ be the substring of _pattern_ from position _nextIndex_, exclusive, to position _length_, exclusive.
-          1. Add new part record { [[Type]]: `"literal"`, [[Value]]: _literal_ } as a new element of the list _result_.
+          1. Add new part Record { [[Type]]: `"literal"`, [[Value]]: _literal_ } as a new element of the list _result_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -150,8 +149,8 @@
       <emu-alg>
         1. Let _parts_ be ? PartitionRelativeTimePattern(_relativeTimeFormat_, _value_, _unit_).
         1. Let _result_ be an empty String.
-        1. For each _part_ in _parts_, do:
-          1. Set _result_ to a String value produced by concatenating _result_ and _part_.[[Value]].
+        1. For each _part_ in _parts_, do
+          1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -167,7 +166,7 @@
         1. Let _parts_ be ? PartitionRelativeTimePattern(_relativeTimeFormat_, _value_, _unit_).
         1. Let _result_ be ArrayCreate(0).
         1. Let _n_ be 0.
-        1. For each _part_ in _parts_, do:
+        1. For each _part_ in _parts_, do
           1. Let _O_ be ObjectCreate(%ObjectPrototype%).
           1. Perform ! CreateDataPropertyOrThrow(_O_, `"type"`, _part_.[[Type]]).
           1. Perform ! CreateDataPropertyOrThrow(_O_, `"value"`, _part_.[[Value]]).
@@ -184,7 +183,7 @@
     <h1>The Intl.RelativeTimeFormat Constructor</h1>
 
     <p>
-      The RelativeTimeFormat constructor is a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-properties-of-intl-relativetimeformat-instances"></emu-xref>.
+      The RelativeTimeFormat constructor is the <dfn>%RelativeTimeFormat%</dfn> intrinsic object and a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
     </p>
 
     <emu-clause id="sec-Intl.RelativeTimeFormat">
@@ -196,7 +195,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _relativeTimeFormat_ be ! OrdinaryCreateFromConstructor(NewTarget, `"%RelativeTimeFormatPrototype%"`, « [[InitializedRelativeTimeFormat]], [[Locale]], [[Style]], [[Numeric]], [[Fields]], [[NumberFormat]], [[PluralRules]] »).
+        1. Let _relativeTimeFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%RelativeTimeFormatPrototype%"`, « [[InitializedRelativeTimeFormat]], [[Locale]], [[Style]], [[Numeric]], [[Fields]], [[NumberFormat]], [[PluralRules]] »).
         1. Return ? InitializeRelativeTimeFormat(_relativeTimeFormat_, _locales_, _options_).
       </emu-alg>
     </emu-clause>
@@ -213,7 +212,7 @@
       <h1>Intl.RelativeTimeFormat.prototype</h1>
 
       <p>
-        The value of *Intl.RelativeTimeFormat.prototype* is *%RelativeTimeFormatPrototype%*.
+        The value of `Intl.RelativeTimeFormat.prototype` is %RelativeTimeFormatPrototype%.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.
@@ -224,13 +223,13 @@
       <h1>Intl.RelativeTimeFormat.supportedLocalesOf ( _locales_ [, _options_ ])</h1>
 
       <p>
-        When the *supportedLocalesOf* method of *%RelativeTimeFormat%* is called, the following steps are taken:
+        When the `supportedLocalesOf` method of %RelativeTimeFormat% is called, the following steps are taken:
       </p>
 
       <emu-alg>
-        1. Let _availableLocales_ be *%RelativeTimeFormat%*.[[AvailableLocales]].
-        1. Let _requestedLocales_ be CanonicalizeLocaleList(_locales_).
-        1. Return SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
+        1. Let _availableLocales_ be %RelativeTimeFormat%.[[AvailableLocales]].
+        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
+        1. Return ? SupportedLocales(_availableLocales_, _requestedLocales_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -238,7 +237,7 @@
       <h1>Internal slots</h1>
 
       <p>
-        The value of the [[AvailableLocales]] internal slot is implementation-defined within the constraints described in <emu-xref href="#sec-properties-of-intl-relativetimeformat-instances"></emu-xref>.
+        The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref>.
       </p>
 
       <p>
@@ -250,11 +249,11 @@
       </emu-note>
 
       <p>
-        The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-properties-of-intl-relativetimeformat-instances"></emu-xref> and the following additional constraints:
+        The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints:
       </p>
 
       <ul>
-        <li>[[LocaleData]][Locale] has ordinary data properties `"second"`, `"minute"`, `"hour"`, `"day"`, `"week"`, `"month"`, `"quarter"` and `"year"`. Additional property keys may exist with the previous names concatenated with the strings `"-narrow"` or `"-short"`. The values corresponding to these property keys are objects which contain these two categories of properties:
+        <li>[[LocaleData]][Locale] has ordinary data properties `"second"`, `"minute"`, `"hour"`, `"day"`, `"week"`, `"month"`, `"quarter"`, and `"year"`. Additional property keys may exist with the previous names concatenated with the strings `"-narrow"` or `"-short"`. The values corresponding to these property keys are objects which contain these two categories of properties:
         <ul>
         <li>`"future"` and `"past"` properties, which are objects with a property for each of the [[PluralCategories]] in the Locale. The value corresponding to those properties is a pattern which may contain `"{0}"` to be replaced by a formatted number.</li>
         <li>Optionally, additional properties whose key is the result of ToString of a Number, and whose values are literal Strings which are not treated as templates.</li>
@@ -272,14 +271,14 @@
     <h1>Properties of the Intl.RelativeTimeFormat Prototype Object</h1>
 
     <p>
-      The Intl.RelativeTimeFormat prototype object is itself an ordinary object. %RelativeTimeFormatPrototype% is not an Intl.RelativeTimeFormat instance and does not have an [[InitializedRelativeTimeFormat]] internal slot or any of the other internal slots of Intl.RelativeTimeFormat instance objects.
+      The Intl.RelativeTimeFormat prototype object is itself an ordinary object. <dfn>%RelativeTimeFormatPrototype%</dfn> is not an Intl.RelativeTimeFormat instance and does not have an [[InitializedRelativeTimeFormat]] internal slot or any of the other internal slots of Intl.RelativeTimeFormat instance objects.
     </p>
 
     <emu-clause id="sec-Intl.RelativeTimeFormat.prototype.constructor">
       <h1>Intl.RelativeTimeFormat.prototype.constructor</h1>
 
       <p>
-        The initial value of *Intl.RelativeTimeFormat.prototype.constructor* is *%RelativeTimeFormat%*.
+        The initial value of `Intl.RelativeTimeFormat.prototype.constructor` is %RelativeTimeFormat%.
       </p>
     </emu-clause>
 
@@ -298,12 +297,13 @@
       <h1>Intl.RelativeTimeFormat.prototype.format( _value_, _unit_ )</h1>
 
       <p>
-        When the *Intl.RelativeTimeFormat.prototype.format* is called with arguments _value_ and _unit_, the following steps are taken:
+        When the `format` method is called with arguments _value_ and _unit_, the following steps are taken:
       </p>
 
       <emu-alg>
         1. Let _relativeTimeFormat_ be the *this* value.
-        1. If Type(_relativeTimeFormat_) is not Object or _relativeTimeFormat_ does not have an [[InitializedRelativeTimeFormat]] internal slot, throw a TypeError exception.
+        1. If Type(_relativeTimeFormat_) is not Object, throw a *TypeError* exception.
+        1. If _relativeTimeFormat_ does not have an [[InitializedRelativeTimeFormat]] internal slot, throw a *TypeError* exception.
         1. Let _value_ be ? ToNumber(_value_).
         1. Let _unit_ be ? ToString(_unit_).
         1. Return ? FormatRelativeTime(_relativeTimeFormat_, _value_, _unit_).
@@ -314,12 +314,13 @@
       <h1>Intl.RelativeTimeFormat.prototype.formatToParts( _value_, _unit_ )</h1>
 
       <p>
-        When the *Intl.RelativeTimeFormat.prototype.formatToParts* is called with arguments _value_ and _unit_, the following steps are taken:
+        When the `formatToParts` method is called with arguments _value_ and _unit_, the following steps are taken:
       </p>
 
       <emu-alg>
         1. Let _relativeTimeFormat_ be the *this* value.
-        1. If Type(_relativeTimeFormat_) is not Object or _relativeTimeFormat_ does not have an [[InitializedRelativeTimeFormat]] internal slot, throw a TypeError exception.
+        1. If Type(_relativeTimeFormat_) is not Object, throw a *TypeError* exception.
+        1. If _relativeTimeFormat_ does not have an [[InitializedRelativeTimeFormat]] internal slot, throw a *TypeError* exception.
         1. Let _value_ be ? ToNumber(_value_).
         1. Let _unit_ be ? ToString(_unit_).
         1. Return ? FormatRelativeTimeToParts(_relativeTimeFormat_, _value_, _unit_).
@@ -334,13 +335,13 @@
       </p>
 
       <emu-alg>
-        1. Let _pr_ be the the *this* value.
-        1. If Type(_pr_) is not Object, throw a *TypeError* exception.
-        1. If _pr_ does not have an [[InitializedRelativeTimeFormat]] internal slot, throw a *TypeError* exception.
+        1. Let _relativeTimeFormat_ be the *this* value.
+        1. If Type(_relativeTimeFormat_) is not Object, throw a *TypeError* exception.
+        1. If _relativeTimeFormat_ does not have an [[InitializedRelativeTimeFormat]] internal slot, throw a *TypeError* exception.
         1. Let _options_ be ! ObjectCreate(%ObjectPrototype%).
         1. For each row of <emu-xref href="#table-relativetimeformat-resolvedoptions-properties"></emu-xref>, except the header row, in table order, do
           1. Let _p_ be the Property value of the current row.
-          1. Let _v_ be the value of _pr_'s internal slot whose name is the Internal Slot value of the current row.
+          1. Let _v_ be the value of _relativeTimeFormat_'s internal slot whose name is the Internal Slot value of the current row.
           1. Assert: _v_ is not *undefined*.
           1. Perform ! CreateDataPropertyOrThrow(_options_, _p_, _v_).
         1. Return _options_.
@@ -376,7 +377,7 @@
     <h1>Properties of Intl.RelativeTimeFormat Instances</h1>
 
     <p>
-      Intl.RelativeTimeFormat instances are ordinary objects that inherit properties from *%RelativeTimeFormatPrototype%*.
+      Intl.RelativeTimeFormat instances are ordinary objects that inherit properties from %RelativeTimeFormatPrototype%.
     </p>
 
     <p>
@@ -390,7 +391,7 @@
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
       <li>[[Style]] is one of the String values `"long"`, `"short"`, or `"narrow"`, identifying the relative time format style used.</li>
-      <li>[[Numeric]] is one of the String values `"always"`, or `"auto"`, identifying whether numerical descriptions are always used, or used only when no more specific version is available (e.g., "1 day ago" vs "yesterday").</li>
+      <li>[[Numeric]] is one of the String values `"always"` or `"auto"`, identifying whether numerical descriptions are always used, or used only when no more specific version is available (e.g., "1 day ago" vs "yesterday").</li>
     </ul>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
Details:
- Add "," after "Else".
- Remove "*" around %foo% references.
- Replace "?" with "!" when accessing spec internal objects which should never throw.
- Add Oxford comma.
- Remove "then" in concise if-steps.
- Add backticks around string literals.
- Add French quotes for Lists in Call operations.
- Replace ":" with "do" in loop steps.
- Add dfn for %RelativeTimeFormat% and %RelativeTimeFormatPrototype%
- Add missing "?" for fallible operations.
- Add missing biblio entries.
- Update preamble descriptions for prototype methods to match current ECMA 402 spec.
- Split type checks in "format[ToParts]" to match ECMA 402.
- Add missing "*" around error constructor names.