### PR TITLE
Add missing `now` result

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ in 1 sec.
 in 1 sec.
 1 sec. ago
 2 sec. ago
+now
 ```
 
 ### `Intl.RelativeTimeFormat.prototype.formatToParts(value, unit)`


### PR DESCRIPTION
`new Intl.RelativeTimeFormat('en', {numeric: 'auto'}).format(0, 'second')` produces `now`