### PR TITLE
Fix MakePartsList algorithm

### DIFF
--- a/spec/biblio.json
+++ b/spec/biblio.json
@@ -46,6 +46,11 @@
       "type": "clause",
       "number": "9.1",
       "id": "sec-internal-slots"
-    }
+    },
+    {
+      "type": "op",
+      "aoid": "PartitionPattern",
+      "id": "sec-partitionpattern"
+    }	    
   ]
 }

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -127,13 +127,12 @@
         1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. Let _result_ be a new empty List.
         1. For each element _patternPart_ of _patternParts_, in List order, do
-          1. Let _part_ be _patternPart_.[[Type]].
-          1. If _part_ is `"literal"`, then
+          1. If _patternPart_.[[Type]] is `"literal"`, then
             1. Append Record { [[Type]]: `"literal"`, [[Value]]: _patternPart_.[[Value]] } to _result_.
           1. Else,
-            1. Assert: _part_ is `"0"`
+            1. Assert: _patternPart_.[[Type]] is `"0"`.
             1. For each _part_ in _parts_, do
-              1. Add new part Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: _unit_ } as a new element on the List _result_.
+              1. Append Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: _unit_ } to _result_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -124,22 +124,16 @@
         </pre>
       </p>
       <emu-alg>
+        1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. Let _result_ be a new empty List.
-        1. Let _beginIndex_ be ! Call(%StringProto_indexOf%, _pattern_, « "{", *0* »).
-        1. Let _length_ be the number of elements in _pattern_.
-        1. Repeat, while _beginIndex_ is an integer index into _pattern_
-          1. Set _endIndex_ to ! Call(%StringProto_indexOf%, _pattern_, « "}", _beginIndex_ »).
-          1. Assert: _endIndex_ is not -1, otherwise the pattern would be malformed.
-          1. If _beginIndex_ is greater than _nextIndex_, then
-            1. Let _literal_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
-            1. Add new part Record { [[Type]]: `"literal"`, [[Value]]: _literal_ } as a new element of the list _result_.
-          1. Let _p_ be the substring of _pattern_ from position _beginIndex_, exclusive, to position _endIndex_, exclusive.
-          1. Assert: _p_ is `"0"`.
-          1. For each _part_ in _parts_, do
-            1. Add new part Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: _unit_ } as a new element on the List _result_.
-        1. If _nextIndex_ is less than _length_, then
-          1. Let _literal_ be the substring of _pattern_ from position _nextIndex_, exclusive, to position _length_, exclusive.
-          1. Add new part Record { [[Type]]: `"literal"`, [[Value]]: _literal_ } as a new element of the list _result_.
+        1. For each element _patternPart_ of _patternParts_, in List order, do
+          1. Let _part_ be _patternPart_.[[Type]].
+          1. If _part_ is `"literal"`, then
+            1. Append Record { [[Type]]: `"literal"`, [[Value]]: _patternPart_.[[Value]] } to _result_.
+          1. Else,
+            1. Assert: _part_ is `"0"`
+            1. For each _part_ in _parts_, do
+              1. Add new part Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: _unit_ } as a new element on the List _result_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Right now `nextIndex` gets neither initialized nor updated, so is
`beginIndex`, which makes the loop never terminate.

Reference impl:
https://github.com/formatjs/formatjs/blob/master/packages/intl-relativetimeformat/src/core.ts#L143-L174