### PR TITLE
Editorial: Fixing PartitionRelativeTimePattern preamble

### DIFF
--- a/spec/relativetimeformat.html
+++ b/spec/relativetimeformat.html
@@ -66,7 +66,7 @@
       <h1>PartitionRelativeTimePattern ( _relativeTimeFormat_, _value_, _unit_ )</h1>
 
       <p>
-        When the FormatRelativeTime abstract operation is called with arguments _relativeTimeFormat_, _value_, and _unit_ it returns a String value representing _value_ (interpreted as a time value as specified in ES2016, 20.3.1.1) according to the effective locale and the formatting options of _relativeTimeFormat_.
+        When the FormatRelativeTime abstract operation is called with arguments _relativeTimeFormat_, _value_, and _unit_ it returns a String value representing _value_ (which must be a Number value) according to the effective locale and the formatting options of _relativeTimeFormat_.
       </p>
 
       <emu-alg>


### PR DESCRIPTION
Fixing PartitionRelativeTimePattern preamble to state that `value` should be a Number value.

It closes #95.